### PR TITLE
[LB-415] 레벨 테스트 컨트롤러 API 엔드포인트 경로 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'com.lgcms'
-version = '0.6'
+version = '0.7'
 
 java {
 	toolchain {

--- a/src/main/java/com/lgcms/leveltest/controller/LevelTestController.java
+++ b/src/main/java/com/lgcms/leveltest/controller/LevelTestController.java
@@ -21,33 +21,33 @@ public class LevelTestController {
     private final CategoryRedisRepository categoryRedisRepository;
     
     // 문제 추가
-    @PostMapping("")
+    @PostMapping("/questions")
     public ResponseEntity<BaseResponse<LevelTestResponse>> createQuestion(@Valid @RequestBody LevelTestRequest request) {
         return ResponseEntity.ok(BaseResponse.ok(levelTestService.createQuestion(request)));
     }
     
     // 문제 수정
-    @PutMapping("/{id}")
+    @PutMapping("/questions/{id}")
     public ResponseEntity<BaseResponse<LevelTestResponse>> updateQuestion(@PathVariable @Valid Long id,
                                                           @Valid @RequestBody LevelTestRequest request) {
         return ResponseEntity.ok(BaseResponse.ok(levelTestService.updateQuestion(id, request)));
     }
     
     // 문제 삭제
-    @DeleteMapping("/{id}")
+    @DeleteMapping("/questions/{id}")
     public ResponseEntity<BaseResponse<String>> deleteQuestion(@PathVariable @Valid Long id) {
         levelTestService.deleteQuestion(id);
         return ResponseEntity.ok(BaseResponse.ok("삭제 완료"));
     }
     
     // 특정 문제 조회
-    @GetMapping("/{id}")
+    @GetMapping("/questions/{id}")
     public ResponseEntity<BaseResponse<LevelTestResponse>> getQuestion(@PathVariable @Valid Long id) {
         return ResponseEntity.ok(BaseResponse.ok(levelTestService.getQuestion(id)));
     }
 
     // 전체 문제 조회
-    @GetMapping("")
+    @GetMapping("/questions")
     public ResponseEntity<BaseResponse<List<LevelTestResponse>>> getAllQuestions() {
         return ResponseEntity.ok(BaseResponse.ok(levelTestService.getAllQuestions()));
     }


### PR DESCRIPTION
## 작업 내용
    - LevelTestController와 LevelTestReportController 간의 URL 경로 충돌 해결을 위한 엔드포인트 경로 수정